### PR TITLE
Update booking terms header text

### DIFF
--- a/src/pages/BookingForm.tsx
+++ b/src/pages/BookingForm.tsx
@@ -619,7 +619,7 @@ const BookingForm = () => {
                 <div className="text-white text-sm leading-relaxed space-y-4">
                   <div>
                     <h3 className="text-amber-400 font-semibold mb-2">
-                      YOUNG CIRCLE EMPIRE – BOOKING TERMS & CONDITIONS
+                      BOOKING TERMS & CONDITIONS
                     </h3>
                     <p className="text-gray-300">
                       These Terms & Conditions govern all studio session


### PR DESCRIPTION
Simplified the booking terms and conditions header text by removing "YOUNG CIRCLE EMPIRE –" prefix.

Changed from:
"YOUNG CIRCLE EMPIRE – BOOKING TERMS & CONDITIONS"

To:
"BOOKING TERMS & CONDITIONS"

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c23188d3b88e4383b37b8d711886d24c/stellar-field)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c23188d3b88e4383b37b8d711886d24c</projectId>-->
<!--<branchName>stellar-field</branchName>-->